### PR TITLE
Add frontmatter and link to non-markdown file

### DIFF
--- a/conferences.md
+++ b/conferences.md
@@ -1,3 +1,7 @@
+---
+layout: default
+---
+
 # Conference list
 A list of conferences relevant to people in the civic tech, govtech, tech for good space. Data should contain NAME, DATES (for the next year), and a WEBSITE.
 
@@ -14,7 +18,7 @@ Service Design in Governnment - 20190306 - https://govservicedesign.net/2019/ (E
 TICTeC - 20190319 - https://tictec.mysociety.org/2019 (Paris)
 
 **April**
-Personal Democracy Forum - Gdansk, Poland 4-5 April (with festival of Civic Tech on 6th April) 
+Personal Democracy Forum - Gdansk, Poland 4-5 April (with festival of Civic Tech on 6th April)
 
 **May**
 

--- a/index.md
+++ b/index.md
@@ -1,3 +1,7 @@
+---
+layout: default
+---
+
 # The Doctorate
 I'm using this page as a set of resources to cover work done on my DPhil so that it is easy to keep track of where I am up to, the work that I'm reading and where it could be useful in other contexts.
 
@@ -6,4 +10,4 @@ I'm using this page as a set of resources to cover work done on my DPhil so that
 - [Trello board](https://trello.com/b/L96iEWs1)
 - Article lists
 - [Medium Blogging](https://medium.com/civictechresearch)
-- [Conference list](https://blangry.github.io/thedoctorate/conferences.md)
+- [Conference list](conferences)


### PR DESCRIPTION
You need frontmatter on your .md files to let Jekyll know which theme layout to use. 

Don't link to the conference.md file, link to either ./conference or ./conference.html